### PR TITLE
fix: constrain compose editor height and keep buttons visible

### DIFF
--- a/src/components/mail/compose.tsx
+++ b/src/components/mail/compose.tsx
@@ -181,7 +181,7 @@ export function Compose({
       {/* Form */}
       <form
         onSubmit={handleSubmit}
-        className="flex-1 flex flex-col p-4 gap-4 overflow-y-auto"
+        className="flex-1 flex flex-col p-4 gap-4 min-h-0"
       >
         {/* From (if multiple identities) */}
         {identities.length > 1 && (
@@ -268,7 +268,7 @@ export function Compose({
         </div>
 
         {/* Body - Rich Text Editor */}
-        <div className="flex-1 flex flex-col min-h-[250px]">
+        <div className="flex-1 flex flex-col min-h-0">
           <Label className="sr-only">Message</Label>
           <RichTextEditor
             value={body}
@@ -285,7 +285,7 @@ export function Compose({
         )}
 
         {/* Actions */}
-        <div className="flex gap-2">
+        <div className="shrink-0 flex gap-2">
           <Button type="submit" disabled={isLoading}>
             <HugeiconsIcon icon={MailSend01Icon} className="h-4 w-4 mr-2" />
             {isLoading ? 'Sending...' : 'Send'}

--- a/src/components/mail/rich-text-editor.tsx
+++ b/src/components/mail/rich-text-editor.tsx
@@ -153,7 +153,7 @@ export function RichTextEditor({
   }
 
   return (
-    <div className="flex flex-col border rounded-md bg-background">
+    <div className="flex-1 flex flex-col min-h-0 border rounded-md bg-background">
       {/* Toolbar */}
       <div className="flex items-center gap-0.5 p-1 border-b bg-muted/30">
         {/* Text Formatting */}


### PR DESCRIPTION
## Summary

- Fix issue where composing an email with very long body text pushes the Send/Cancel buttons off-screen
- Constrain the rich text editor to fill available space and scroll internally instead of growing unbounded
- Make buttons always visible below the editor by using shrink-0 instead of sticky positioning