### PR TITLE
fix: false negative logout action

### DIFF
--- a/src/routes/_authed/mail/route.tsx
+++ b/src/routes/_authed/mail/route.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { Link, Outlet, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   LogoutIcon,
@@ -44,9 +44,12 @@ function MailLayout() {
     document.documentElement.classList.toggle('dark', isDark)
   }, [isDark])
 
+  const navigate = useNavigate()
+
   const handleLogout = async () => {
     try {
       await logoutFn()
+      await navigate({ to: '/login' })
     } catch {
       toast.error('Failed to log out')
     }

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -65,7 +65,7 @@ export const loginFn = createServerFn({ method: 'POST' })
 export const logoutFn = createServerFn({ method: 'POST' }).handler(async () => {
   const session = await useAppSession()
   await session.clear()
-  throw redirect({ to: '/login' })
+  return { success: true }
 })
 
 /**


### PR DESCRIPTION
This pull request updates the logout flow in the authenticated mail route to improve user experience and code clarity. Instead of performing a server-side redirect on logout, the client now handles navigation to the login page after a successful logout, providing better control and error handling.

**Logout flow improvements:**

* Changed the `logoutFn` server function in `src/server/auth.ts` to return a success object instead of performing a server-side redirect, allowing the client to manage navigation after logout.
* Updated the `MailLayout` component in `src/routes/_authed/mail/route.tsx` to use the `useNavigate` hook and navigate to `/login` on successful logout, improving client-side control and user feedback. [[1]](diffhunk://#diff-09684455ab3743b4024c21d250d5ecd828963f599eba1a4237415ac6573c24d7L2-R2) [[2]](diffhunk://#diff-09684455ab3743b4024c21d250d5ecd828963f599eba1a4237415ac6573c24d7R47-R52)